### PR TITLE
SNARK Trait Compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,12 @@ snarkos-profiler = { path = "../snarkOS/profiler", version = "0.8.0" }
 snarkos-utilities = { path = "../snarkOS/utilities", version = "0.8.0" }
 poly-commit = { path = "../poly-commit", default-features = false }
 
+blake2 = { version = "0.8", default-features = false }
+derivative = { version = "2", features = ["use_core"] }
+digest = { version = "0.8" }
 rand_core = { version = "0.5" }
 rand_chacha = { version = "0.2.1", default-features = false }
 rayon = { version = "1", optional = true }
-digest = { version = "0.8" }
-derivative = { version = "2", features = ["use_core"] }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ rayon = { version = "1", optional = true }
 
 
 [dev-dependencies]
-blake2 = { version = "0.8", default-features = false }
 snarkos-curves = { path = "../snarkOS/curves", version = "0.8.0" }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,12 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-snarkos-models = { path = "../snarkOS/models", version = "0.8.0" }
 snarkos-algorithms = { path = "../snarkOS/algorithms", version = "0.8.0" }
-snarkos-utilities = { path = "../snarkOS/utilities", version = "0.8.0" }
-snarkos-profiler = { path = "../snarkOS/profiler", version = "0.8.0" }
-snarkos-gadgets = { path = "../snarkOS/gadgets", version = "0.8.0" }
 snarkos-errors = { path = "../snarkOS/errors", version = "0.8.0" }
-
+snarkos-gadgets = { path = "../snarkOS/gadgets", version = "0.8.0" }
+snarkos-models = { path = "../snarkOS/models", version = "0.8.0" }
+snarkos-profiler = { path = "../snarkOS/profiler", version = "0.8.0" }
+snarkos-utilities = { path = "../snarkOS/utilities", version = "0.8.0" }
 poly-commit = { path = "../poly-commit", default-features = false }
 
 rand_core = { version = "0.5" }

--- a/src/ahp/constraint_systems.rs
+++ b/src/ahp/constraint_systems.rs
@@ -1,16 +1,19 @@
 #![allow(non_snake_case)]
 
-use crate::ahp::indexer::Matrix;
-use crate::ahp::*;
-use crate::{BTreeMap, Cow, String, ToString};
+use crate::{
+    ahp::{indexer::Matrix, *},
+    BTreeMap, Cow, String, ToString,
+};
 use derivative::Derivative;
 use poly_commit::LabeledPolynomial;
 use snarkos_algorithms::{cfg_iter_mut, fft::Evaluations as EvaluationsOnDomain};
-use snarkos_errors::gadgets::SynthesisError;
+use snarkos_errors::{gadgets::SynthesisError, serialization::SerializationError};
 use snarkos_models::{
     curves::{batch_inversion, Field, PrimeField},
     gadgets::r1cs::{ConstraintSystem, Index as VarIndex, LinearCombination, Variable},
 };
+
+use snarkos_utilities::serialize::*;
 
 // #[cfg(feature = "parallel")]
 // use rayon::prelude::*;
@@ -218,6 +221,7 @@ pub(crate) fn make_matrices_square<F: Field, CS: ConstraintSystem<F>>(
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "F: PrimeField"))]
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct MatrixEvals<'a, F: PrimeField> {
     /// Evaluations of the LDE of row.
     pub row: Cow<'a, EvaluationsOnDomain<F>>,
@@ -231,6 +235,7 @@ pub struct MatrixEvals<'a, F: PrimeField> {
 /// Here `M^*(i, j) := M(j, i) * u_H(j, j)`. For more details, see [COS19].
 #[derive(Derivative)]
 #[derivative(Clone(bound = "F: PrimeField"))]
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct MatrixArithmetization<'a, F: PrimeField> {
     /// LDE of the row indices of M^*.
     pub row: LabeledPolynomial<'a, F>,

--- a/src/ahp/mod.rs
+++ b/src/ahp/mod.rs
@@ -37,7 +37,8 @@ impl<F: PrimeField> AHPForR1CS<F> {
         // Polynomials for C
         "c_row", "c_col", "c_val", "c_row_col",
     ];
-
+    /// THe linear combinations that are statically known to evaluate to zero.
+    pub const LC_WITH_ZERO_EVAL: [&'static str; 2] = ["inner_sumcheck", "outer_sumcheck"];
     /// The labels for the polynomials output by the AHP prover.
     #[rustfmt::skip]
     pub const PROVER_POLYNOMIALS: [&'static str; 9] = [
@@ -46,9 +47,6 @@ impl<F: PrimeField> AHPForR1CS<F> {
         // Second sumcheck
         "g_2", "h_2",
     ];
-
-    /// THe linear combinations that are statically known to evaluate to zero.
-    pub const LC_WITH_ZERO_EVAL: [&'static str; 2] = ["inner_sumcheck", "outer_sumcheck"];
 
     pub(crate) fn polynomial_labels() -> impl Iterator<Item = String> {
         Self::INDEXER_POLYNOMIALS

--- a/src/ahp/verifier.rs
+++ b/src/ahp/verifier.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
 
-use crate::ahp::indexer::IndexInfo;
-use crate::ahp::*;
+use crate::ahp::{indexer::IndexInfo, *};
 use rand_core::RngCore;
 
 use poly_commit::QuerySet;

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -148,7 +148,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, C: ConstraintSynthesizer<F>> Pr
 
     /// Prints information about the size of the proof.
     pub fn print_size_info(&self) {
-        use poly_commit::{PCCommitment, PCProof};
+        use poly_commit::PCCommitment;
 
         let size_of_fe_in_bytes = F::zero().into_repr().as_ref().len() * 8;
         let mut num_comms_without_degree_bounds = 0;
@@ -159,17 +159,17 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, C: ConstraintSynthesizer<F>> Pr
         for c in self.commitments.iter().flat_map(|c| c) {
             if !c.has_degree_bound() {
                 num_comms_without_degree_bounds += 1;
-                size_bytes_comms_without_degree_bounds += c.size_in_bytes();
+                size_bytes_comms_without_degree_bounds += c.serialized_size();
             } else {
                 num_comms_with_degree_bounds += 1;
-                size_bytes_comms_with_degree_bounds += c.size_in_bytes();
+                size_bytes_comms_with_degree_bounds += c.serialized_size();
             }
         }
 
         let proofs: Vec<PC::Proof> = self.pc_proof.proof.clone().into();
         let num_proofs = proofs.len();
         for proof in &proofs {
-            size_bytes_proofs += proof.size_in_bytes();
+            size_bytes_proofs += proof.serialized_size();
         }
 
         let num_evals = self.evaluations.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub mod ahp;
 pub use ahp::AHPForR1CS;
 use ahp::EvaluationsProvider;
 
+pub mod snark;
+
 #[cfg(test)]
 mod test;
 

--- a/src/snark.rs
+++ b/src/snark.rs
@@ -23,10 +23,12 @@ use std::{
 };
 
 // Instantiated type aliases for convenience
+/// A structured reference string which will be used to derive a circuit-specific
+/// common reference string
+pub type SRS<E> = crate::UniversalSRS<<E as PairingEngine>::Fr, MultiPC<E>>;
 type Marlin<E> = crate::Marlin<<E as PairingEngine>::Fr, MultiPC<E>, Blake2s>;
 type VerifierKey<E, C> = crate::IndexVerifierKey<<E as PairingEngine>::Fr, MultiPC<E>, C>;
 type ProverKey<'a, E, C> = crate::IndexProverKey<'a, <E as PairingEngine>::Fr, MultiPC<E>, C>;
-type SRS<E> = crate::UniversalSRS<<E as PairingEngine>::Fr, MultiPC<E>>;
 type Proof<E, C> = crate::Proof<<E as PairingEngine>::Fr, MultiPC<E>, C>;
 
 /// SnarkOS-compatible Marlin

--- a/src/snark.rs
+++ b/src/snark.rs
@@ -12,7 +12,7 @@ use snarkos_utilities::{
     serialize::*,
 };
 
-use poly_commit::marlin_pc::MarlinKZG10 as MultiPC;
+pub use poly_commit::marlin_pc::MarlinKZG10 as MultiPC;
 
 use blake2::Blake2s;
 use derivative::Derivative;
@@ -26,7 +26,10 @@ use std::{
 /// A structured reference string which will be used to derive a circuit-specific
 /// common reference string
 pub type SRS<E> = crate::UniversalSRS<<E as PairingEngine>::Fr, MultiPC<E>>;
-type Marlin<E> = crate::Marlin<<E as PairingEngine>::Fr, MultiPC<E>, Blake2s>;
+
+/// Type alias for a Marlin instance using the KZG10 polynomial commitment and Blake2s
+pub type Marlin<E> = crate::Marlin<<E as PairingEngine>::Fr, MultiPC<E>, Blake2s>;
+
 type VerifierKey<E, C> = crate::IndexVerifierKey<<E as PairingEngine>::Fr, MultiPC<E>, C>;
 type ProverKey<'a, E, C> = crate::IndexProverKey<'a, <E as PairingEngine>::Fr, MultiPC<E>, C>;
 type Proof<E, C> = crate::Proof<<E as PairingEngine>::Fr, MultiPC<E>, C>;

--- a/src/snark.rs
+++ b/src/snark.rs
@@ -1,0 +1,153 @@
+//! Marlin adapted for the SnarkOS SNARK trait
+use snarkos_errors::{algorithms::SNARKError, serialization::SerializationError};
+use snarkos_models::{
+    algorithms::SNARK,
+    curves::{to_field_vec::ToConstraintField, PairingEngine},
+    gadgets::r1cs::ConstraintSynthesizer,
+};
+use snarkos_profiler::{end_timer, start_timer};
+use snarkos_utilities::{
+    bytes::{FromBytes, ToBytes},
+    error, io,
+    serialize::*,
+};
+
+use poly_commit::marlin_pc::MarlinKZG10 as MultiPC;
+
+use blake2::Blake2s;
+use derivative::Derivative;
+use rand_core::RngCore;
+use std::{
+    io::{Read, Write},
+    marker::PhantomData,
+};
+
+// Instantiated type aliases for convenience
+type Marlin<E> = crate::Marlin<<E as PairingEngine>::Fr, MultiPC<E>, Blake2s>;
+type VerifierKey<E, C> = crate::IndexVerifierKey<<E as PairingEngine>::Fr, MultiPC<E>, C>;
+type ProverKey<'a, E, C> = crate::IndexProverKey<'a, <E as PairingEngine>::Fr, MultiPC<E>, C>;
+type SRS<E> = crate::UniversalSRS<<E as PairingEngine>::Fr, MultiPC<E>>;
+type Proof<E, C> = crate::Proof<<E as PairingEngine>::Fr, MultiPC<E>, C>;
+
+/// SnarkOS-compatible Marlin
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MarlinSnark<'a, E, C, V>
+where
+    E: PairingEngine,
+    C: ConstraintSynthesizer<E::Fr>,
+    V: ToConstraintField<E::Fr>,
+{
+    _engine: PhantomData<E>,
+    _circuit: PhantomData<C>,
+    _verifier_input: PhantomData<V>,
+    _key_lifetime: PhantomData<&'a ProverKey<'a, E, C>>,
+}
+
+#[derive(Derivative)]
+#[derivative(Clone(bound = "C: 'a"))]
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
+/// The public parameters used for the circuit's instantiation.
+/// Generating the parameters is done via the `setup` function of the SNARK trait
+/// by providing it the previously generated universal srs.
+pub struct Parameters<'a, E, C>
+where
+    E: PairingEngine,
+    C: ConstraintSynthesizer<E::Fr>,
+{
+    /// The proving key
+    pub prover_key: ProverKey<'a, E, C>,
+    /// The verifying key
+    pub verifier_key: VerifierKey<E, C>,
+}
+
+impl<'a, E: PairingEngine, C: ConstraintSynthesizer<E::Fr>> FromBytes for Parameters<'a, E, C> {
+    fn read<R: Read>(mut r: R) -> io::Result<Self> {
+        CanonicalDeserialize::deserialize(&mut r)
+            .map_err(|_| error("could not deserialize parameters"))
+    }
+}
+
+impl<'a, E: PairingEngine, C: ConstraintSynthesizer<E::Fr>> ToBytes for Parameters<'a, E, C> {
+    fn write<W: Write>(&self, mut w: W) -> io::Result<()> {
+        CanonicalSerialize::serialize(self, &mut w)
+            .map_err(|_| error("could not serialize parameters"))
+    }
+}
+
+impl<'a, E, C> Parameters<'a, E, C>
+where
+    E: PairingEngine,
+    C: ConstraintSynthesizer<E::Fr>,
+{
+    /// Creates a new Parameters instance from a previously computed universal SRS
+    pub fn new(circuit: C, universal_srs: SRS<E>) -> Result<Self, SNARKError> {
+        let (prover_key, verifier_key) = Marlin::index(universal_srs, circuit)
+            .map_err(|_| SNARKError::Message("could not index".to_owned()))?;
+        Ok(Self {
+            prover_key,
+            verifier_key,
+        })
+    }
+}
+
+impl<'a, E, C> From<Parameters<'a, E, C>> for VerifierKey<E, C>
+where
+    E: PairingEngine,
+    C: ConstraintSynthesizer<E::Fr>,
+{
+    fn from(params: Parameters<'a, E, C>) -> Self {
+        params.verifier_key
+    }
+}
+
+impl<'a, E, C, V> SNARK for MarlinSnark<'a, E, C, V>
+where
+    E: PairingEngine,
+    C: ConstraintSynthesizer<E::Fr>,
+    V: ToConstraintField<E::Fr>,
+{
+    type AssignedCircuit = C;
+    type Circuit = (C, SRS<E>); // Abuse the Circuit type to pass the SRS as well.
+    type PreparedVerificationParameters = VerifierKey<E, C>;
+    type Proof = Proof<E, C>;
+    type ProvingParameters = Parameters<'a, E, C>;
+    type VerificationParameters = VerifierKey<E, C>;
+    type VerifierInput = V;
+
+    fn setup<R: RngCore>(
+        (circuit, srs): Self::Circuit,
+        _rng: &mut R, // The Marlin Setup is deterministic
+    ) -> Result<
+        (
+            Self::ProvingParameters,
+            Self::PreparedVerificationParameters,
+        ),
+        SNARKError,
+    > {
+        let setup_time = start_timer!(|| "{Marlin}::Setup");
+        let parameters = Parameters::<E, C>::new(circuit, srs)?;
+        end_timer!(setup_time);
+        let verifier_key = parameters.verifier_key.clone();
+        Ok((parameters, verifier_key))
+    }
+
+    fn prove<R: RngCore>(
+        pp: &Self::ProvingParameters,
+        circuit: Self::AssignedCircuit,
+        rng: &mut R,
+    ) -> Result<Self::Proof, SNARKError> {
+        let proof = Marlin::prove(&pp.prover_key, circuit, rng).unwrap();
+        Ok(proof)
+    }
+
+    fn verify(
+        vk: &Self::PreparedVerificationParameters,
+        input: &Self::VerifierInput,
+        proof: &Self::Proof,
+    ) -> Result<bool, SNARKError> {
+        let rng = &mut rand_core::OsRng;
+        Marlin::verify(&vk, &input.to_field_elements().unwrap(), &proof, rng).unwrap();
+
+        Ok(true)
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -80,7 +80,8 @@ mod marlin {
                 num_variables,
             };
 
-            let (index_pk, index_vk) = MarlinInst::index(&universal_srs, circ.clone()).unwrap();
+            let (index_pk, index_vk) =
+                MarlinInst::index(universal_srs.clone(), circ.clone()).unwrap();
             println!("Called index");
 
             let proof = MarlinInst::prove(&index_pk, circ, rng).unwrap();


### PR DESCRIPTION
Depends on https://github.com/AleoHQ/poly-commit/pull/3 & https://github.com/AleoHQ/snarkOS/pull/261.

Notable changes: 
- indexing takes SRS by value instead of by reference (lifetime issue which I didn't figure out, requires clone'ing the SRS in tests)
- The `SNARK::Circuit` type is "abused" so that we can pass the SRS during the setup.
- The verifier takes an `OsRng` instance in order to do the batch openings of the polycommits. The SNARK trait currently does not let us pass a `&mut impl Rng` argument (or hack it in the `VerificationParameters` type. I think this is good enough, although we should keep that in mind, in case we end up wanting to make the trait slightly more flexible.